### PR TITLE
Fix exception that occurs when collapse lines is bigger than line count

### DIFF
--- a/expandabletextview/src/main/kotlin/net/expandable/ExpandableTextView.kt
+++ b/expandabletextview/src/main/kotlin/net/expandable/ExpandableTextView.kt
@@ -141,6 +141,7 @@ class ExpandableTextView : TextView {
 
     private fun performEllipsize() {
         if (visibility == VISIBLE) {
+            if (layout.lineCount <= collapseLines) return
             val avail = (0 until collapseLines)
                     .map { layout.getLineMax(it) }
                     .sum()


### PR DESCRIPTION
ref: #18 